### PR TITLE
Add staging of partial entries and tests

### DIFF
--- a/.sqlx/query-3309a641a6e9efc0c362de507662fd21b5e09619b203fd497c73539f720ad4de.json
+++ b/.sqlx/query-3309a641a6e9efc0c362de507662fd21b5e09619b203fd497c73539f720ad4de.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n    update market_data md \n    set stock_traded = coalesce(md.stock_traded, pgd.stock_traded ),\n              \"open\" = coalesce(md.open, pgd.\"open\"),\n             \"close\" = coalesce(md.\"close\" , pgd.\"close\"),\n        order_amount = coalesce(md.order_amount , pgd.order_amount),\n         stock_price = coalesce(md.stock_price , pgd.\"close\")\n    from polygon_grouped_daily pgd \n    where \n        pgd.is_staged = false \n    and pgd.symbol = md.symbol\n    and pgd.business_date = md.business_date\n    and md.year_month = (EXTRACT(YEAR FROM pgd.business_date) * 100) + EXTRACT(MONTH FROM pgd.business_date)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "3309a641a6e9efc0c362de507662fd21b5e09619b203fd497c73539f720ad4de"
+}

--- a/.sqlx/query-511a581efc9d5185fdb974881192a49c96a794381c8086c0a4caa74b660e1354.json
+++ b/.sqlx/query-511a581efc9d5185fdb974881192a49c96a794381c8086c0a4caa74b660e1354.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select is_staged from polygon_grouped_daily where business_date = '2022-03-07'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "is_staged",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "511a581efc9d5185fdb974881192a49c96a794381c8086c0a4caa74b660e1354"
+}

--- a/.sqlx/query-540bb656df034e4443793c7eaeaa013f943a3ccf5b7cfb8c22ac0829f04a903f.json
+++ b/.sqlx/query-540bb656df034e4443793c7eaeaa013f943a3ccf5b7cfb8c22ac0829f04a903f.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select is_staged from polygon_grouped_daily where business_date = '2022-03-04'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "is_staged",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "540bb656df034e4443793c7eaeaa013f943a3ccf5b7cfb8c22ac0829f04a903f"
+}

--- a/.sqlx/query-7c70925f9255cc177769af8cb77fd670951be2a41ecd6c1a2b6b6450b1d20e2f.json
+++ b/.sqlx/query-7c70925f9255cc177769af8cb77fd670951be2a41ecd6c1a2b6b6450b1d20e2f.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select order_amount from market_data where business_date = '2022-03-07'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "order_amount",
+        "type_info": "Float8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "7c70925f9255cc177769af8cb77fd670951be2a41ecd6c1a2b6b6450b1d20e2f"
+}

--- a/.sqlx/query-9056102a9d6e9c4fa2665c4df0682e72a8fc108f945be2826618302d32e681cd.json
+++ b/.sqlx/query-9056102a9d6e9c4fa2665c4df0682e72a8fc108f945be2826618302d32e681cd.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select order_amount from market_data where business_date = '2022-03-09'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "order_amount",
+        "type_info": "Float8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "9056102a9d6e9c4fa2665c4df0682e72a8fc108f945be2826618302d32e681cd"
+}

--- a/.sqlx/query-bdac35936d72c54b3ba411c5a61db00d77770997c1049c00531c4be3ac30724f.json
+++ b/.sqlx/query-bdac35936d72c54b3ba411c5a61db00d77770997c1049c00531c4be3ac30724f.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select is_staged from polygon_grouped_daily where business_date = '2022-03-09'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "is_staged",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "bdac35936d72c54b3ba411c5a61db00d77770997c1049c00531c4be3ac30724f"
+}

--- a/.sqlx/query-ce202a7ce15ca33fa2e77643c53cfe8f2e9edcc8b3ade66d22ed3ddd21163e72.json
+++ b/.sqlx/query-ce202a7ce15ca33fa2e77643c53cfe8f2e9edcc8b3ade66d22ed3ddd21163e72.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select order_amount from market_data where business_date = '2022-03-08'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "order_amount",
+        "type_info": "Float8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "ce202a7ce15ca33fa2e77643c53cfe8f2e9edcc8b3ade66d22ed3ddd21163e72"
+}

--- a/.sqlx/query-e939f7b8b77c211b344189a0278b607f732f604b5c8850fab025e0043de0bea9.json
+++ b/.sqlx/query-e939f7b8b77c211b344189a0278b607f732f604b5c8850fab025e0043de0bea9.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select is_staged from polygon_grouped_daily where business_date = '2022-03-08'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "is_staged",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e939f7b8b77c211b344189a0278b607f732f604b5c8850fab025e0043de0bea9"
+}

--- a/tests/resources/collectors/staging/polygon_grouped_daily_staging/market_data_update_entries.sql
+++ b/tests/resources/collectors/staging/polygon_grouped_daily_staging/market_data_update_entries.sql
@@ -1,0 +1,12 @@
+INSERT INTO market_data
+(symbol, business_date, year_month, stock_price, "open", "close", stock_traded, order_amount, after_hours, pre_market, market_capitalization)
+VALUES('A', '2022-03-04', 202203, 133.89, 1.0, 133.89, 3848511.0, 48479.0, NULL, NULL, NULL);
+INSERT INTO market_data
+(symbol, business_date, year_month, stock_price, "open", "close", stock_traded, order_amount, after_hours, pre_market, market_capitalization)
+VALUES('A', '2022-03-07', 202203, 130.34, 133.55, 130.34, 2376504.0, NULL, NULL, NULL, NULL);
+INSERT INTO market_data
+(symbol, business_date, year_month, stock_price, "open", "close", stock_traded, order_amount, after_hours, pre_market, market_capitalization)
+VALUES('A', '2022-03-08', 202203, 130.34, 133.55, 130.34, 2376504.0, NULL, NULL, NULL, NULL);
+INSERT INTO market_data
+(symbol, business_date, year_month, stock_price, "open", "close", stock_traded, order_amount, after_hours, pre_market, market_capitalization)
+VALUES('A', '2022-03-09', 202203, 130.34, 133.55, 130.34, 2376504.0, 10.0, NULL, NULL, NULL);

--- a/tests/resources/collectors/staging/polygon_grouped_daily_staging/polygon_grouped_daily_data_source.sql
+++ b/tests/resources/collectors/staging/polygon_grouped_daily_staging/polygon_grouped_daily_data_source.sql
@@ -1,0 +1,13 @@
+INSERT INTO polygon_grouped_daily
+("close", business_date, high, low, "open", symbol, order_amount, stock_traded, volume_weighted_average_price, is_staged)
+VALUES(133.8900, '2022-03-04', 137.1200, 132.1400, 135.8500, 'A', 48479, 3848511.0000, 134.2259, false);
+INSERT INTO polygon_grouped_daily
+("close", business_date, high, low, "open", symbol, order_amount, stock_traded, volume_weighted_average_price, is_staged)
+VALUES(130.3400, '2022-03-07', 133.5500, 128.4300, 133.5500, 'A', 36120, 2376504.0000, 130.3950, false);
+INSERT INTO polygon_grouped_daily
+("close", business_date, high, low, "open", symbol, order_amount, stock_traded, volume_weighted_average_price, is_staged)
+VALUES(130.3400, '2022-03-08', 133.5500, 128.4300, 133.5500, 'A', NULL, 2376504.0000, 130.3950, false);
+INSERT INTO polygon_grouped_daily
+("close", business_date, high, low, "open", symbol, order_amount, stock_traded, volume_weighted_average_price, is_staged)
+VALUES(130.3400, '2022-03-09', 133.5500, 128.4300, 133.5500, 'A', NULL, 2376504.0000, 130.3950, false);
+


### PR DESCRIPTION
Partial staging of entries is now possible. Meaning that NULL values in the market data table will be updated, if there is a non-NULL value in the source, without overwriting the other values.
Tests added.